### PR TITLE
Switch database to MySQL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment for Codex API using MySQL
+# Update the password, host and port if necessary
+DATABASE_URL="mysql://root:password@localhost:3306/codex"

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ node_modules/
 dist/
 uploads/
 .prisma/
-prisma/dev.db
+.env

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Generate the Prisma client:
 npx prisma generate
 ```
 
+Copy `.env.example` to `.env` and adjust the connection string if needed. Prisma
+will use this value to connect to MySQL.
+
 Run the application in development mode:
 
 ```bash
@@ -35,6 +38,6 @@ container stack with Docker Compose:
 docker-compose up --build
 ```
 
-The application will be exposed on port `3000` and will automatically create the
-SQLite database inside the `prisma/` directory. Uploaded files are persisted in
-`uploads/` on the host machine.
+The application will be exposed on port `3000` and a MySQL database will be
+started alongside the API. Uploaded files are persisted in `uploads/` on the
+host machine.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,22 @@
 version: "3.8"
 services:
+  db:
+    image: mysql:8.0
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: codex
+    volumes:
+      - db-data:/var/lib/mysql
   api:
     build: .
     ports:
       - "3000:3000"
     volumes:
       - ./uploads:/usr/src/app/uploads
-      - ./prisma/dev.db:/usr/src/app/prisma/dev.db
+    environment:
+      DATABASE_URL: mysql://root:password@db:3306/codex
+    depends_on:
+      - db
+volumes:
+  db-data:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,8 +5,8 @@ generator client {
 }
 
 datasource db {
-  provider = "sqlite"
-  url      = "file:./dev.db"
+  provider = "mysql"
+  url      = env("DATABASE_URL")
 }
 
 model Product {


### PR DESCRIPTION
## Summary
- move Prisma datasource to MySQL
- provide example `.env` with database connection
- update compose stack to run MySQL service
- ignore `.env` file and adjust docs

## Testing
- `npx prisma generate` *(fails: 403 Forbidden)*
- `npm run build` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_6846dd128b148327b878878f457053f9